### PR TITLE
fix(stories): full-passage read-along alignment + publish-on-validate

### DIFF
--- a/components/stories/highlighted-passage.tsx
+++ b/components/stories/highlighted-passage.tsx
@@ -133,7 +133,10 @@ export default function HighlightedPassage({
   const { firstParsedSentence, paragraphs } = useMemo(() => {
     const parsed = sentences.map((sentence, index) => ({
       ...sentence,
-      parts: splitSentenceIntoWords(sentence.sentence),
+      // Guard against missing/empty sentence text: fall back to empty string
+      // so the sentence still occupies its slot (shown but not highlighted)
+      // rather than producing an error or vanishing entirely.
+      parts: splitSentenceIntoWords(sentence.sentence ?? ""),
       originalIndex: index,
     }));
 

--- a/components/stories/storie-content.tsx
+++ b/components/stories/storie-content.tsx
@@ -275,21 +275,28 @@ export default function StorieContent({ chapter }: StorieContentProps) {
             </div>
           )}
 
-          {/* Highlighted Passage or Plain Text */}
-          {hasAudioSupport ? (
+          {/* Highlighted Passage or Plain Text.
+              When sentences are available, always render HighlightedPassage so
+              the DOM tree is identical regardless of audio mode — eliminating
+              the reflow that occurred when toggling "Listen and Read Along".
+              In non-audio mode we pass neutral index values (-1) so nothing is
+              actively highlighted, and omit the click handlers so seeking is
+              inactive. The plain <p> is only the true fallback for when the
+              backend has not yet generated sentence timepoints. */}
+          {sentences.length > 0 ? (
             <HighlightedPassage
               sentences={sentences}
               translations={translations}
-              currentSentenceIndex={currentSentenceIndex}
-              currentWordIndex={currentWordIndex}
-              isPlaying={isPlaying}
-              showTranslation={showTranslation}
+              currentSentenceIndex={isAudioMode ? currentSentenceIndex : -1}
+              currentWordIndex={isAudioMode ? currentWordIndex : -1}
+              isPlaying={isAudioMode && isPlaying}
+              showTranslation={showTranslation && isAudioMode}
               translationLanguage={translationLanguage}
-              onWordClick={handleWordClick}
-              onSentenceClick={handleSentenceClick}
+              onWordClick={isAudioMode ? handleWordClick : undefined}
+              onSentenceClick={isAudioMode ? handleSentenceClick : undefined}
             />
           ) : (
-            // Fallback to plain text when no sentences available
+            // Fallback: no sentence timepoints available yet.
             <p className="font-article text-lg leading-loose md:text-xl">
               {chapter.passage}
             </p>

--- a/hooks/use-audio-player.ts
+++ b/hooks/use-audio-player.ts
@@ -123,6 +123,17 @@ export function useAudioPlayer({
     const { sentenceIndex, wordIndex } = findCurrentPosition(currentTime);
 
     setState((prev) => {
+      // Sticky sentence: when findCurrentPosition returns -1 (time is in a gap
+      // between timed sentences or past the last one), keep the previous sentence
+      // highlighted rather than clearing to nothing. This prevents the read-along
+      // highlight from blanking out mid-playback when timing data has gaps.
+      // Exception: before audio starts (prev.currentSentenceIndex === -1) there
+      // is no "last known good" sentence — leave it as -1 (no highlight yet).
+      const effectiveSentenceIndex =
+        sentenceIndex === -1 && prev.currentSentenceIndex !== -1
+          ? prev.currentSentenceIndex
+          : sentenceIndex;
+
       // Don't update wordIndex if we're in a gap (wordIndex is -1) within the
       // SAME sentence — keep current word highlighted during inter-word gaps.
       // BUT if the sentence just changed, reset to -1: carrying over a word
@@ -130,21 +141,24 @@ export function useAudioPlayer({
       // in the new sentence's alignment map and cause a one-frame blink.
       const effectiveWordIndex =
         wordIndex === -1
-          ? sentenceIndex !== prev.currentSentenceIndex
+          ? effectiveSentenceIndex !== prev.currentSentenceIndex
             ? -1
             : prev.currentWordIndex
           : wordIndex;
 
       const hasChanges =
         prev.currentTime !== currentTime ||
-        prev.currentSentenceIndex !== sentenceIndex ||
+        prev.currentSentenceIndex !== effectiveSentenceIndex ||
         prev.currentWordIndex !== effectiveWordIndex;
 
       if (!hasChanges) return prev;
 
       // Trigger callbacks if indices changed
-      if (prev.currentSentenceIndex !== sentenceIndex && sentenceIndex !== -1) {
-        onSentenceChange?.(sentenceIndex);
+      if (
+        prev.currentSentenceIndex !== effectiveSentenceIndex &&
+        effectiveSentenceIndex !== -1
+      ) {
+        onSentenceChange?.(effectiveSentenceIndex);
       }
       if (
         prev.currentWordIndex !== effectiveWordIndex &&
@@ -156,7 +170,7 @@ export function useAudioPlayer({
       return {
         ...prev,
         currentTime,
-        currentSentenceIndex: sentenceIndex,
+        currentSentenceIndex: effectiveSentenceIndex,
         currentWordIndex: effectiveWordIndex,
       };
     });

--- a/hooks/use-chapter.ts
+++ b/hooks/use-chapter.ts
@@ -25,7 +25,7 @@ export function useChapter(options: UseChapterOptions): UseChapterReturn {
     storyId,
     chapterNumber,
     enabled = true,
-    staleTime = 5 * 60 * 1000, // 5 minutes
+    staleTime = 60 * 1000, // 1 minute — lowered from 5 min so repaired chapter data propagates sooner
   } = options;
 
   const { data, isLoading, isFetching, isError, error, refetch } =

--- a/server/controllers/articleValidationController.ts
+++ b/server/controllers/articleValidationController.ts
@@ -6,7 +6,10 @@ import {
   MAX_REPAIR_ATTEMPTS,
   MAX_BATCH_LIMIT,
 } from "@/server/utils/validators/types";
-import { checkArticle, ArticleForCheck } from "@/server/utils/validators/checks/article-checks";
+import {
+  checkArticle,
+  ArticleForCheck,
+} from "@/server/utils/validators/checks/article-checks";
 import { planArticleRepair } from "@/server/utils/validators/repairs/article-repairs";
 import {
   createValidationRun,
@@ -15,7 +18,10 @@ import {
 } from "@/server/models/validationRunModel";
 import { ValidationLogger } from "@/lib/logger";
 
-export type ValidationMode = "pending_and_broken" | "all_published" | "specific_ids";
+export type ValidationMode =
+  | "pending_and_broken"
+  | "all_published"
+  | "specific_ids";
 
 export interface RunArticleValidationParams {
   mode: ValidationMode;
@@ -60,7 +66,9 @@ export async function runArticleValidation(
   const run = await createValidationRun("article", params.triggeredBy);
   const startedAt = Date.now();
 
-  let articles: Array<Prisma.ArticleGetPayload<{ select: typeof ARTICLE_SELECT }>> = [];
+  let articles: Array<
+    Prisma.ArticleGetPayload<{ select: typeof ARTICLE_SELECT }>
+  > = [];
   const totals = {
     itemsChecked: 0,
     itemsOk: 0,
@@ -168,7 +176,10 @@ async function fetchCandidates(
     where,
     select: ARTICLE_SELECT,
     take: limit,
-    orderBy: [{ validatedAt: { sort: "asc", nulls: "first" } }, { createdAt: "asc" }],
+    orderBy: [
+      { validatedAt: { sort: "asc", nulls: "first" } },
+      { createdAt: "asc" },
+    ],
   });
 }
 
@@ -204,10 +215,17 @@ async function processArticle(
           validatedAt: new Date(),
           repairAttempts: 0,
           lastValidationIssues: Prisma.DbNull,
+          isPublished: true,
         },
       });
     }
-    return { id: article.id, status: ValidationStatus.OK, attempts: article.repairAttempts, issues: [], repairsRun: [] };
+    return {
+      id: article.id,
+      status: ValidationStatus.OK,
+      attempts: article.repairAttempts,
+      issues: [],
+      repairsRun: [],
+    };
   }
 
   // ── Permanently broken? ──
@@ -219,7 +237,8 @@ async function processArticle(
           validationStatus: ValidationStatus.PERMANENTLY_BROKEN,
           validatedAt: new Date(),
           isPublished: false,
-          lastValidationIssues: initialIssues as unknown as Prisma.InputJsonValue,
+          lastValidationIssues:
+            initialIssues as unknown as Prisma.InputJsonValue,
         },
       });
     }
@@ -316,7 +335,11 @@ async function processArticle(
         remainingIssues.length > 0
           ? (remainingIssues as unknown as Prisma.InputJsonValue)
           : Prisma.DbNull,
-      ...(finalStatus === ValidationStatus.PERMANENTLY_BROKEN ? { isPublished: false } : {}),
+      ...(finalStatus === ValidationStatus.OK
+        ? { isPublished: true }
+        : finalStatus === ValidationStatus.PERMANENTLY_BROKEN
+          ? { isPublished: false }
+          : {}),
     },
   });
 

--- a/server/controllers/storieController.ts
+++ b/server/controllers/storieController.ts
@@ -184,7 +184,8 @@ const processCefrLevel = async (
             savedStory.chapters.map((chapter) =>
               generateChapterAudio({
                 passage: chapter.passage,
-                sentences: chapter.sentences as string[],
+                // sentences is now optional; omitting it lets generateChapterAudio
+                // derive full-coverage sentences from the passage (Issue #138 fix).
                 chapterId: chapter.id,
                 chapterNumber: chapter.chapterNumber,
                 cefrLevel: level,

--- a/server/controllers/storyValidationController.ts
+++ b/server/controllers/storyValidationController.ts
@@ -19,7 +19,10 @@ import {
 } from "@/server/models/validationRunModel";
 import { ValidationLogger, ValidationStep } from "@/lib/logger";
 
-export type ValidationMode = "pending_and_broken" | "all_published" | "specific_ids";
+export type ValidationMode =
+  | "pending_and_broken"
+  | "all_published"
+  | "specific_ids";
 
 export interface RunStoryValidationParams {
   mode: ValidationMode;
@@ -149,7 +152,9 @@ export async function runStoryValidation(
   };
 }
 
-type StoryWithChapters = Prisma.StoryGetPayload<{ include: typeof STORY_INCLUDE }>;
+type StoryWithChapters = Prisma.StoryGetPayload<{
+  include: typeof STORY_INCLUDE;
+}>;
 
 async function fetchCandidates(
   params: RunStoryValidationParams,
@@ -181,7 +186,10 @@ async function fetchCandidates(
     where,
     include: STORY_INCLUDE,
     take: limit,
-    orderBy: [{ validatedAt: { sort: "asc", nulls: "first" } }, { createdAt: "asc" }],
+    orderBy: [
+      { validatedAt: { sort: "asc", nulls: "first" } },
+      { createdAt: "asc" },
+    ],
   });
 }
 
@@ -201,14 +209,17 @@ async function processStory(
     summary: story.summary,
     translatedSummary: story.translatedSummary,
   };
-  const chaptersForCheck: StoryChapterForCheck[] = story.storyChapters.map((ch) => ({
-    id: ch.id,
-    chapterNumber: ch.chapterNumber,
-    audioSentencesUrl: ch.audioSentencesUrl,
-    sentences: ch.sentences,
-    translatedSentences: ch.translatedSentences,
-    translatedSummary: ch.translatedSummary,
-  }));
+  const chaptersForCheck: StoryChapterForCheck[] = story.storyChapters.map(
+    (ch) => ({
+      id: ch.id,
+      chapterNumber: ch.chapterNumber,
+      audioSentencesUrl: ch.audioSentencesUrl,
+      sentences: ch.sentences,
+      translatedSentences: ch.translatedSentences,
+      translatedSummary: ch.translatedSummary,
+      passage: ch.passage,
+    }),
+  );
 
   const initialIssues = await checkStory(storyForCheck, chaptersForCheck);
 
@@ -221,6 +232,7 @@ async function processStory(
           validatedAt: new Date(),
           repairAttempts: 0,
           lastValidationIssues: Prisma.DbNull,
+          isPublished: true,
         },
       });
     }
@@ -241,7 +253,8 @@ async function processStory(
           validationStatus: ValidationStatus.PERMANENTLY_BROKEN,
           validatedAt: new Date(),
           isPublished: false,
-          lastValidationIssues: initialIssues as unknown as Prisma.InputJsonValue,
+          lastValidationIssues:
+            initialIssues as unknown as Prisma.InputJsonValue,
         },
       });
     }
@@ -328,6 +341,7 @@ async function processStory(
           sentences: ch.sentences,
           translatedSentences: ch.translatedSentences,
           translatedSummary: ch.translatedSummary,
+          passage: ch.passage,
         })),
       )
     : initialIssues;
@@ -355,7 +369,11 @@ async function processStory(
         remainingIssues.length > 0
           ? (remainingIssues as unknown as Prisma.InputJsonValue)
           : Prisma.DbNull,
-      ...(finalStatus === ValidationStatus.PERMANENTLY_BROKEN ? { isPublished: false } : {}),
+      ...(finalStatus === ValidationStatus.OK
+        ? { isPublished: true }
+        : finalStatus === ValidationStatus.PERMANENTLY_BROKEN
+          ? { isPublished: false }
+          : {}),
     },
   });
 

--- a/server/models/storieModel.ts
+++ b/server/models/storieModel.ts
@@ -37,7 +37,7 @@ export const saveStoryToDB = async (
         imageDescription: story.imageDesc,
         cefrLevel: cefrLevel,
         rating: rating,
-        isPublished: true,
+        isPublished: false,
         characters: story.characters,
         storyChapters: {
           create: story.chapters.map((chapter, index) => ({

--- a/server/utils/genaretors/audio-generator.ts
+++ b/server/utils/genaretors/audio-generator.ts
@@ -26,16 +26,17 @@ import { SENTENCE_SPLITTER_SYSTEM_PROMPT } from "@/data/prompts-ai";
 import winkNLP from "wink-nlp";
 import model from "wink-eng-lite-web-model";
 import { uploadToBucket } from "@/utils/storage";
+import { computeCoverageRatio } from "@/server/utils/validators/sentence-coverage";
 
 interface GenerateAudioParams {
   passage: string;
-  sentences: string[];
+  sentences?: string[]; // Optional: LLM hint. If coverage <90%, passage is re-split.
   articleId: string;
 }
 
 interface GenerateChapterAudioParams {
   passage: string;
-  sentences: string[];
+  sentences?: string[]; // Optional: LLM hint. If coverage <90%, passage is re-split.
   chapterId: string;
   chapterNumber: number;
   cefrLevel?: string;
@@ -146,9 +147,8 @@ export async function splitIntoSentences(passage: string): Promise<string[]> {
   try {
     const userPrompt = `Split the following text into complete sentences, keeping dialogue and attribution together:${passage}`;
 
-    const { model, modelId, providerName, temperature } = await resolveTaskModel(
-      TASK_KEYS.TRANSLATION_SENTENCE,
-    );
+    const { model, modelId, providerName, temperature } =
+      await resolveTaskModel(TASK_KEYS.TRANSLATION_SENTENCE);
     console.log(
       formatTaskLog({
         taskKey: TASK_KEYS.TRANSLATION_SENTENCE,
@@ -178,146 +178,215 @@ export async function splitIntoSentences(passage: string): Promise<string[]> {
   }
 }
 
+// ---------------------------------------------------------------------------
+// Core aligner — rewritten for 0-drop guarantee (Issue #138)
+// ---------------------------------------------------------------------------
+
+const NORMALIZATION_LOOKAHEAD = 4; // max extra TTS tokens to scan past a mismatch
+
+/** Normalize a token for matching: strip non-word chars, lowercase */
+function normalizeToken(s: string): string {
+  return s.replace(/[^\w]/g, "").toLowerCase();
+}
+
+/**
+ * Walk the Lemonfox word_timestamps stream and assign each input sentence a
+ * contiguous span of timestamps. Guarantees:
+ *
+ * 1. Every non-empty input sentence produces exactly one SentenceTimepoint
+ *    (0 sentences dropped).
+ * 2. The .sentence field is the verbatim input text (original punctuation/casing
+ *    preserved — NOT rebuilt from TTS tokens, which strip punctuation).
+ * 3. Tolerant resync: on tokenization drift (contractions, numbers, em-dash),
+ *    lookahead ≤ NORMALIZATION_LOOKAHEAD lets us skip past unmatched TTS tokens
+ *    and anchor on the next confident match. Unmatched words get their timing
+ *    interpolated from neighbors.
+ * 4. Sentences with zero matched words get words:[] with timing interpolated
+ *    from neighboring timepoints.
+ *
+ * @param wordTimestamps - Lemonfox word_timestamps array
+ * @param sentences      - Verbatim sentence strings (from passage)
+ * @param contextId      - Article/chapter ID for log messages
+ */
+export function alignWordTimestampsToSentences(
+  wordTimestamps: WordTimestamp[],
+  sentences: string[],
+  contextId: string,
+): SentenceTimepoint[] {
+  // Filter out empty/whitespace-only sentences before processing
+  const nonEmptySentences = sentences.filter((s) => s.trim().length > 0);
+
+  if (nonEmptySentences.length === 0) return [];
+  if (wordTimestamps.length === 0) {
+    // No timestamps at all — emit every sentence with zero-width timing
+    return nonEmptySentences.map((sentence) => ({
+      startTime: 0,
+      endTime: 0,
+      words: [],
+      sentence: sentence.trim(),
+    }));
+  }
+
+  // Build a normalized token list once for efficient scanning
+  const normTokens = wordTimestamps.map((wt) => normalizeToken(wt.word));
+
+  // Cursor into wordTimestamps — advances as sentences claim tokens
+  let cursor = 0;
+
+  // Pass 1: For each sentence, collect matched word timestamps using tolerant scan
+  const rawResults: Array<{
+    sentence: string;
+    words: WordTimestamp[];
+    startTime: number | null;
+    endTime: number | null;
+  }> = nonEmptySentences.map((sentence) => {
+    const cleanSentence = sentence.trim();
+    const sentenceTokens = cleanSentence
+      .split(/[\s—–]+/) // split on whitespace, em-dash, en-dash
+      .map((w) => normalizeToken(w))
+      .filter((w) => w.length > 0);
+
+    const matchedWords: WordTimestamp[] = [];
+    let startTime: number | null = null;
+    let endTime: number | null = null;
+
+    for (let si = 0; si < sentenceTokens.length; si++) {
+      const expected = sentenceTokens[si];
+      let found = false;
+
+      // Common path: check at cursor position first (1:1 positional)
+      if (cursor < wordTimestamps.length && normTokens[cursor] === expected) {
+        const wt = wordTimestamps[cursor];
+        matchedWords.push(wt);
+        if (startTime === null) startTime = wt.start;
+        endTime = wt.end;
+        cursor++;
+        found = true;
+      } else {
+        // Tolerant scan: look ahead up to NORMALIZATION_LOOKAHEAD positions
+        // for a confident match, then interpolate the skipped tokens
+        for (
+          let ahead = 1;
+          ahead <= NORMALIZATION_LOOKAHEAD &&
+          cursor + ahead < wordTimestamps.length;
+          ahead++
+        ) {
+          if (normTokens[cursor + ahead] === expected) {
+            // Found a confident match — consume the skipped tokens without
+            // advancing their timing (they'll be interpolated later) but
+            // update the cursor so we don't stall.
+            const wt = wordTimestamps[cursor + ahead];
+            matchedWords.push(wt);
+            if (startTime === null) startTime = wt.start;
+            endTime = wt.end;
+            cursor = cursor + ahead + 1;
+            found = true;
+            break;
+          }
+        }
+      }
+
+      if (!found) {
+        // Word absent from TTS stream (contraction half, number, etc.)
+        // We log it but do NOT drop the sentence. Timing will be interpolated.
+        console.warn(
+          `[alignWordTimestampsToSentences][${contextId}] unmatched token` +
+            ` "${expected}" in sentence "${cleanSentence.substring(0, 40)}..."`,
+        );
+      }
+    }
+
+    return { sentence: cleanSentence, words: matchedWords, startTime, endTime };
+  });
+
+  // Pass 2: Interpolate timing for sentences with zero matched words using
+  // their neighbors' timing. This satisfies the 0-drop guarantee.
+  const timepoints: SentenceTimepoint[] = rawResults.map((r, i) => {
+    if (r.startTime !== null && r.endTime !== null) {
+      return {
+        startTime: r.startTime,
+        endTime: r.endTime,
+        words: r.words,
+        sentence: r.sentence,
+      };
+    }
+
+    // Find nearest predecessor with timing
+    let prevEnd = 0;
+    for (let j = i - 1; j >= 0; j--) {
+      if (rawResults[j].endTime !== null) {
+        prevEnd = rawResults[j].endTime!;
+        break;
+      }
+    }
+
+    // Find nearest successor with timing
+    let nextStart: number | null = null;
+    for (let j = i + 1; j < rawResults.length; j++) {
+      if (rawResults[j].startTime !== null) {
+        nextStart = rawResults[j].startTime!;
+        break;
+      }
+    }
+
+    // Interpolate: place this sentence in the gap between neighbors
+    const interpolatedStart = prevEnd;
+    const interpolatedEnd = nextStart !== null ? nextStart : prevEnd + 0.5; // 0.5s fallback if no successor
+
+    return {
+      startTime: interpolatedStart,
+      endTime: interpolatedEnd,
+      words: [],
+      sentence: r.sentence,
+    };
+  });
+
+  // Drop-rate assertion: log an error if >5% of sentences had zero matched words
+  const droppedCount = timepoints.filter((tp) => tp.words.length === 0).length;
+  const dropRate = droppedCount / timepoints.length;
+  if (dropRate > 0.05) {
+    console.error(
+      `[alignWordTimestampsToSentences][${contextId}] drop rate ${(dropRate * 100).toFixed(1)}% ` +
+        `(${droppedCount}/${timepoints.length} sentences have no matched words). ` +
+        `Check TTS tokenization or sentence splitter output.`,
+    );
+  } else if (droppedCount > 0) {
+    console.warn(
+      `[alignWordTimestampsToSentences][${contextId}] ${droppedCount}/${timepoints.length} sentences` +
+        ` have interpolated timing (no matched words) — within 5% tolerance.`,
+    );
+  }
+
+  return timepoints;
+}
+
+/**
+ * @deprecated Use alignWordTimestampsToSentences instead.
+ * Kept for any internal callers that reference the old name during transition.
+ */
 function processWordTimestampsIntoSentences(
   wordTimestamps: WordTimestamp[],
   sentences: string[],
-  articleId: string,
+  contextId: string,
 ): SentenceTimepoint[] {
-  const sentenceTimepoints: SentenceTimepoint[] = [];
-
-  // Split the original passage into sentences using a more sophisticated approach
-  // const sentences = splitIntoSentences(passage);
-
-  let wordIndex = 0;
-  let hasProblems = false;
-  const problemsLog: any[] = [];
-
-  sentences.forEach((sentence, sentenceIndex) => {
-    const sentenceWords: WordTimestamp[] = [];
-    const cleanSentence = sentence.trim();
-
-    // Get the actual words from this sentence
-    const sentenceWordsList = cleanSentence
-      .split(/[\s\—\–]+/)
-      .map((word) => word.replace(/[^\w]/g, "").toLowerCase())
-      .filter((word) => word.length > 0);
-
-    let sentenceStartTime = null;
-    let sentenceEndTime = null;
-    let wordsFound = 0;
-    const missingWords: string[] = [];
-
-    // Look for each word from the sentence in the word timestamps
-    for (const expectedWord of sentenceWordsList) {
-      let wordFound = false;
-
-      // Search through remaining timestamps for this word
-      let searchIndex = wordIndex;
-      while (searchIndex < wordTimestamps.length) {
-        const timestamp = wordTimestamps[searchIndex];
-        const timestampWord = timestamp.word
-          .replace(/[^\w]/g, "")
-          .toLowerCase();
-
-        if (timestampWord === expectedWord) {
-          // Found the word - add it to sentence
-          sentenceWords.push({
-            ...timestamp,
-            word: timestamp.word.replace(/[.!?,;:'"""()[\]{}…]+/g, ""),
-          });
-
-          if (sentenceStartTime === null) {
-            sentenceStartTime = timestamp.start;
-          }
-          sentenceEndTime = timestamp.end;
-
-          // Update wordIndex to continue from next word
-          wordIndex = searchIndex + 1;
-          wordsFound++;
-          wordFound = true;
-          break;
-        }
-        searchIndex++;
-      }
-
-      if (!wordFound) {
-        missingWords.push(expectedWord);
-        hasProblems = true;
-        // console.warn(
-        //   `Missing timestamp for word: "${expectedWord}" in sentence: "${cleanSentence.substring(0, 50)}..."`,
-        // );
-      }
-    }
-
-    // Log missing words for debugging
-    if (missingWords.length > 0) {
-      problemsLog.push({
-        sentenceIndex,
-        sentence: cleanSentence,
-        expectedWords: sentenceWordsList,
-        missingWords,
-        wordsFound,
-        totalWords: sentenceWordsList.length,
-      });
-      // console.log(`Missing words from timestamps:`, missingWords);
-      // console.log(
-      //   `Found ${wordsFound}/${sentenceWordsList.length} words for sentence`,
-      // );
-    }
-
-    // Create sentence timepoint even if some words are missing
-    if (
-      sentenceWords.length > 0 &&
-      sentenceStartTime !== null &&
-      sentenceEndTime !== null
-    ) {
-      sentenceTimepoints.push({
-        startTime: sentenceStartTime,
-        endTime: sentenceEndTime,
-        words: sentenceWords,
-        sentence: cleanSentence,
-      });
-    } else if (sentenceWords.length === 0) {
-      hasProblems = true;
-      problemsLog.push({
-        sentenceIndex,
-        sentence: cleanSentence,
-        error: "No words found for sentence",
-        expectedWords: sentenceWordsList,
-      });
-      // console.error(`No words found for sentence: "${cleanSentence}"`);
-    }
-  });
-  // Only create log file if there are problems
-  // if (hasProblems) {
-  //   createLogFile(
-  //     articleId,
-  //     {
-  //       status: "PROBLEMS_DETECTED",
-  //       wordTimestampsCount: wordTimestamps.length,
-  //       sentencesCount: sentences.length,
-  //       problemsCount: problemsLog.length,
-  //       problems: problemsLog,
-  //       wordTimestamps: wordTimestamps,
-  //       sentences: sentences,
-  //     },
-  //     "problems",
-  //   );
-
-  //   console.log(
-  //     `⚠️  Processing completed with problems. Log file created for article: ${articleId}`,
-  //   );
-  // }
-
-  return sentenceTimepoints;
+  return alignWordTimestampsToSentences(wordTimestamps, sentences, contextId);
 }
 
 export async function generateAudio({
   passage,
-  sentences,
+  sentences: sentenceHint,
   articleId,
 }: GenerateAudioParams): Promise<void> {
   try {
+    // ── Conditional-split gate (mirrors generateChapterAudio) ──
+    // Use the LLM-provided sentence hint only when it covers ≥90% of the passage.
+    // Otherwise derive sentences from passage via the LLM-based splitter so the
+    // aligner has full coverage and the read-along never drops a sentence.
+    const hintSentences = sentenceHint ?? [];
+    const hintCoverage = computeCoverageRatio(hintSentences, passage);
+    const passageSentences =
+      hintCoverage >= 0.9 ? hintSentences : await splitIntoSentences(passage);
+
     const voice = VOICES_AI[Math.floor(Math.random() * VOICES_AI.length)];
 
     const response = await fetch("https://api.lemonfox.ai/v1/audio/speech", {
@@ -363,7 +432,7 @@ export async function generateAudio({
     // Process word timestamps into sentence timepoints
     const sentenceTimepoints = processWordTimestampsIntoSentences(
       json.word_timestamps,
-      sentences,
+      passageSentences,
       articleId,
     );
 
@@ -401,7 +470,7 @@ const AUDIO_RETRY_DELAY_BASE = 1000;
 
 export async function generateChapterAudio({
   passage,
-  sentences,
+  sentences: sentenceHint,
   chapterId,
   chapterNumber,
   cefrLevel,
@@ -413,6 +482,15 @@ export async function generateChapterAudio({
 }> {
   const localPath = `${process.cwd()}/data/audios/${chapterId}.mp3`;
   const cloudPath = `audios/story/chapter/${chapterId}.mp3`;
+
+  // ── Phase 0: Determine passage sentences (conditional-split, cost-saving) ──
+  // If the caller provides a sentence hint that already covers ≥90% of the
+  // passage text, use it as-is (no LLM call). Otherwise derive sentences from
+  // the passage via the LLM-based splitter.
+  const hintSentences = sentenceHint ?? [];
+  const hintCoverage = computeCoverageRatio(hintSentences, passage);
+  const passageSentences =
+    hintCoverage >= 0.9 ? hintSentences : await splitIntoSentences(passage);
 
   // ── Phase 1: Generate audio + write to disk (retry on TTS/write failure) ──
   let json: any;
@@ -478,10 +556,11 @@ export async function generateChapterAudio({
   // Always clean up temp file after upload phase (success or fail)
   await fsPromises.unlink(localPath).catch(() => {});
 
-  // ── Phase 3: Process timestamps + update DB ──
-  const sentenceTimepoints = processWordTimestampsIntoSentences(
+  // ── Phase 3: Align timestamps → produce full-coverage timepoints ──
+  // passageSentences are verbatim passage substrings → 0-drop guarantee.
+  const sentenceTimepoints = alignWordTimestampsToSentences(
     json.word_timestamps,
-    sentences,
+    passageSentences,
     chapterId,
   );
 
@@ -493,10 +572,14 @@ export async function generateChapterAudio({
     },
   });
 
-  // ── Phase 4: Translate sentences ──
+  // ── Phase 4: Translate — derived from FINAL timepoints (1:1 guaranteed) ──
+  // Extract verbatim sentence texts from the stored timepoints so the
+  // translatedSentences[locale][i] always aligns with timepoint[i].
+  const alignedSentenceTexts = sentenceTimepoints.map((tp) => tp.sentence);
+
   try {
     await translateAndStoreSentencesForStory({
-      sentences,
+      sentences: alignedSentenceTexts,
       chapterId,
       chapterNumber,
       cefrLevel,

--- a/server/utils/genaretors/sentence-translator.ts
+++ b/server/utils/genaretors/sentence-translator.ts
@@ -73,9 +73,8 @@ async function translateSentencesWithAI(
           Provide translations in the exact same order, maintaining sentence structure and meaning appropriate for language learners.`;
 
   try {
-    const { model, modelId, providerName, temperature } = await resolveTaskModel(
-      TASK_KEYS.TRANSLATION_SENTENCE,
-    );
+    const { model, modelId, providerName, temperature } =
+      await resolveTaskModel(TASK_KEYS.TRANSLATION_SENTENCE);
     console.log(
       formatTaskLog({
         taskKey: TASK_KEYS.TRANSLATION_SENTENCE,
@@ -145,31 +144,82 @@ export async function translateAndStoreSentences({
       throw new Error(`No sentences to translate for article ${articleId}`);
     }
 
-    // Translate sentences
-    const translatedSentences = await translateSentencesWithAI(
-      sentences,
-      targetLanguages,
-      article.cefrLevel,
-    );
-
-    // Validate that all translations have the same number of sentences
     const originalCount = sentences.length;
-    const translationCounts = {
-      th: translatedSentences.th.length,
-      cn: translatedSentences.cn.length,
-      tw: translatedSentences.tw.length,
-      vi: translatedSentences.vi.length,
-    };
 
-    const invalidCounts = Object.entries(translationCounts).filter(
-      ([_, count]) => count !== originalCount,
-    );
+    // ── Attempt batch translation (3 retries, same as story path) ──
+    let translatedSentences: TranslatedSentences | null = null;
+    let attempts = 0;
+    const maxAttempts = 3;
 
-    if (invalidCounts.length > 0) {
-      console.warn(`Translation count mismatch for article ${articleId}:`, {
-        original: originalCount,
-        translations: translationCounts,
-      });
+    while (attempts < maxAttempts) {
+      try {
+        const candidate = await translateSentencesWithAI(
+          sentences,
+          targetLanguages,
+          article.cefrLevel,
+        );
+
+        const counts = {
+          th: candidate.th.length,
+          cn: candidate.cn.length,
+          tw: candidate.tw.length,
+          vi: candidate.vi.length,
+        };
+
+        const mismatched = Object.entries(counts).filter(
+          ([_, count]) => count !== originalCount,
+        );
+
+        if (mismatched.length > 0) {
+          throw new Error(
+            `Translation count mismatch for article ${articleId}: ` +
+              `Original ${originalCount}, Got ${JSON.stringify(counts)}`,
+          );
+        }
+
+        translatedSentences = candidate;
+        break;
+      } catch (error) {
+        attempts++;
+        console.warn(
+          `[translateAndStoreSentences] attempt ${attempts} failed: ${error}.`,
+        );
+        if (attempts < maxAttempts) {
+          console.warn(`Retrying...`);
+        }
+      }
+    }
+
+    // ── Per-sentence fallback on persistent count-mismatch ──
+    // NEVER trim/pad — that silently misaligns translations (wrong tooltip for learners).
+    // Translate each sentence individually (1:1 guaranteed). If one fails, leave null.
+    if (translatedSentences === null) {
+      console.warn(
+        `[translateAndStoreSentences][${articleId}] batch translation ` +
+          `failed after ${maxAttempts} attempts — falling back to per-sentence translation.`,
+      );
+
+      const perSentence = await Promise.all(
+        sentences.map((s) => translateSingleSentence(s, article.cefrLevel)),
+      );
+
+      translatedSentences = {
+        th: perSentence.map((r) => r.th ?? ""),
+        cn: perSentence.map((r) => r.cn ?? ""),
+        tw: perSentence.map((r) => r.tw ?? ""),
+        vi: perSentence.map((r) => r.vi ?? ""),
+      };
+
+      const nullCount = perSentence.filter(
+        (r) => r.th === null || r.cn === null || r.tw === null || r.vi === null,
+      ).length;
+      if (nullCount > 0) {
+        console.warn(
+          `[translateAndStoreSentences][${articleId}] ` +
+            `${nullCount}/${sentences.length} sentences have null translations — ` +
+            `stored as empty strings. No tooltip for those sentences.`,
+        );
+      }
     }
 
     // Store translations in database
@@ -185,6 +235,36 @@ export async function translateAndStoreSentences({
       error,
     );
     throw new Error(`Failed to translate sentences: ${error.message}`);
+  }
+}
+
+/**
+ * Translate a single sentence for all target languages.
+ * Returns null entries for languages that fail — never throws.
+ */
+async function translateSingleSentence(
+  sentence: string,
+  cefrLevel?: string,
+): Promise<{
+  th: string | null;
+  cn: string | null;
+  tw: string | null;
+  vi: string | null;
+}> {
+  try {
+    const result = await translateSentencesWithAI(
+      [sentence],
+      ["th", "cn", "tw", "vi"],
+      cefrLevel,
+    );
+    return {
+      th: result.th[0] ?? null,
+      cn: result.cn[0] ?? null,
+      tw: result.tw[0] ?? null,
+      vi: result.vi[0] ?? null,
+    };
+  } catch {
+    return { th: null, cn: null, tw: null, vi: null };
   }
 }
 
@@ -204,7 +284,6 @@ export async function translateAndStoreSentencesForStory({
   forceRetranslate?: boolean;
 }): Promise<void> {
   try {
-    // Check if translations already exist and forceRetranslate is false
     if (sentences.length === 0 && !forceRetranslate) {
       console.log(
         `Translations already exist for article. Use forceRetranslate=true to retranslate.`,
@@ -212,44 +291,82 @@ export async function translateAndStoreSentencesForStory({
       return;
     }
 
+    const originalCount = sentences.length;
+    let translatedSentences: TranslatedSentences | null = null;
+
+    // ── Attempt batch translation (3 retries) ──
     let attempts = 0;
     const maxAttempts = 3;
-    let translatedSentences: TranslatedSentences | null = null;
 
     while (attempts < maxAttempts) {
       try {
-        translatedSentences = await translateSentencesWithAI(
+        const candidate = await translateSentencesWithAI(
           sentences,
           targetLanguages,
           cefrLevel,
         );
 
-        const originalCount = sentences.length;
-        const translationCounts = {
-          th: translatedSentences.th.length,
-          cn: translatedSentences.cn.length,
-          tw: translatedSentences.tw.length,
-          vi: translatedSentences.vi.length,
+        const counts = {
+          th: candidate.th.length,
+          cn: candidate.cn.length,
+          tw: candidate.tw.length,
+          vi: candidate.vi.length,
         };
 
-        const invalidCounts = Object.entries(translationCounts).filter(
+        const mismatched = Object.entries(counts).filter(
           ([_, count]) => count !== originalCount,
         );
 
-        if (invalidCounts.length > 0) {
-          const errorMsg = `Translation count mismatch for article ${chapterId}: Original ${originalCount}, Got ${JSON.stringify(translationCounts)}`;
-          throw new Error(errorMsg);
-        }
-
-        break; // Exit loop if successful
-      } catch (error) {
-        attempts++;
-        console.warn(`Attempt ${attempts} failed: ${error}. Retrying...`);
-        if (attempts === maxAttempts) {
+        if (mismatched.length > 0) {
           throw new Error(
-            `Failed to translate sentences after ${maxAttempts} attempts`,
+            `Translation count mismatch for chapter ${chapterId}: ` +
+              `Original ${originalCount}, Got ${JSON.stringify(counts)}`,
           );
         }
+
+        translatedSentences = candidate;
+        break;
+      } catch (error) {
+        attempts++;
+        console.warn(
+          `[translateAndStoreSentencesForStory] attempt ${attempts} failed: ${error}.`,
+        );
+        if (attempts < maxAttempts) {
+          console.warn(`Retrying...`);
+        }
+      }
+    }
+
+    // ── Per-sentence fallback on persistent count-mismatch ──
+    // NEVER trim/pad — that silently misaligns translations (wrong tooltip for learners).
+    // Instead translate each sentence individually (1:1 guaranteed). If one fails,
+    // leave null for that position rather than shift everything.
+    if (translatedSentences === null) {
+      console.warn(
+        `[translateAndStoreSentencesForStory][${chapterId}] batch translation ` +
+          `failed after ${maxAttempts} attempts — falling back to per-sentence translation.`,
+      );
+
+      const perSentence = await Promise.all(
+        sentences.map((s) => translateSingleSentence(s, cefrLevel)),
+      );
+
+      translatedSentences = {
+        th: perSentence.map((r) => r.th ?? ""),
+        cn: perSentence.map((r) => r.cn ?? ""),
+        tw: perSentence.map((r) => r.tw ?? ""),
+        vi: perSentence.map((r) => r.vi ?? ""),
+      };
+
+      const nullCount = perSentence.filter(
+        (r) => r.th === null || r.cn === null || r.tw === null || r.vi === null,
+      ).length;
+      if (nullCount > 0) {
+        console.warn(
+          `[translateAndStoreSentencesForStory][${chapterId}] ` +
+            `${nullCount}/${sentences.length} sentences have null translations — ` +
+            `stored as empty strings. No tooltip for those sentences.`,
+        );
       }
     }
 
@@ -262,7 +379,7 @@ export async function translateAndStoreSentencesForStory({
     });
   } catch (error: any) {
     console.error(
-      `Failed to translate sentences for article ${chapterId}:`,
+      `Failed to translate sentences for chapter ${chapterId}:`,
       error,
     );
     throw new Error(`Failed to translate sentences: ${error.message}`);

--- a/server/utils/validators/checks/article-checks.ts
+++ b/server/utils/validators/checks/article-checks.ts
@@ -5,6 +5,13 @@ import {
   REQUIRED_LOCALES,
   EXPECTED_IMAGES_PER_ARTICLE,
 } from "@/server/utils/validators/types";
+import {
+  computeCoverageRatio,
+  checkTimingIntegrity,
+  COVERAGE_THRESHOLD,
+  FIRST_START_MAX_S,
+  INTER_GAP_MAX_S,
+} from "@/server/utils/validators/sentence-coverage";
 
 interface ArticleSentence {
   startTime?: number;
@@ -59,12 +66,47 @@ export async function checkArticle(article: ArticleForCheck): Promise<Issue[]> {
     issues.push({ type: "sentences_empty" });
   }
 
+  // ── A4b: Coverage check — sentence text must cover ≥ COVERAGE_THRESHOLD of passage ──
+  // Detects partial coverage (issue #138): when the stored timepoints or legacy string[]
+  // only cover a fraction of the article's passage text.
+  if (sentences.length > 0 && article.passage) {
+    const coverageRatio = computeCoverageRatio(
+      article.sentences,
+      article.passage,
+    );
+    if (coverageRatio < COVERAGE_THRESHOLD) {
+      issues.push({
+        type: "sentences_partial_coverage",
+        coverageRatio,
+      });
+    }
+  }
+
+  // ── A4c: Timing-integrity checks on SentenceTimepoint[] ──
+  // Catches: non-monotonic timestamps, overlapping windows, first start > 2s,
+  // inter-timepoint gaps > 3s (a missing/dropped sentence).
+  // Silently skips legacy string[] arrays (no timing data present).
+  const timingViolations = checkTimingIntegrity(article.sentences, {
+    firstStartMaxS: FIRST_START_MAX_S,
+    interGapMaxS: INTER_GAP_MAX_S,
+  });
+  for (const v of timingViolations) {
+    issues.push({
+      type: "sentences_timing_integrity",
+      detail: `${v.kind}${v.detail ? ": " + v.detail : ""}`,
+    });
+  }
+
   // ── A6: translatedPassage complete (per-locale arrays match sentence count) ──
   const tp = (article.translatedPassage ?? {}) as Record<string, unknown>;
   for (const locale of REQUIRED_LOCALES) {
     const arr = tp[locale];
     if (!Array.isArray(arr)) {
-      issues.push({ type: "translation_locale_missing", field: "passage", locale });
+      issues.push({
+        type: "translation_locale_missing",
+        field: "passage",
+        locale,
+      });
       continue;
     }
     if (sentences.length > 0 && arr.length !== sentences.length) {
@@ -83,7 +125,11 @@ export async function checkArticle(article: ArticleForCheck): Promise<Issue[]> {
   for (const locale of REQUIRED_LOCALES) {
     const value = ts[locale];
     if (typeof value !== "string" || value.trim().length === 0) {
-      issues.push({ type: "translation_locale_missing", field: "summary", locale });
+      issues.push({
+        type: "translation_locale_missing",
+        field: "summary",
+        locale,
+      });
     }
   }
 
@@ -97,8 +143,16 @@ export async function checkArticle(article: ArticleForCheck): Promise<Issue[]> {
     issues.push({ type: "flashcard_row_missing" });
   } else {
     await Promise.all([
-      checkFlashcardAudio(flashcardRow.audioSentencesUrl, "flashcard_sentence_audio_missing", issues),
-      checkFlashcardAudio(flashcardRow.wordsUrl, "flashcard_word_audio_missing", issues),
+      checkFlashcardAudio(
+        flashcardRow.audioSentencesUrl,
+        "flashcard_sentence_audio_missing",
+        issues,
+      ),
+      checkFlashcardAudio(
+        flashcardRow.wordsUrl,
+        "flashcard_word_audio_missing",
+        issues,
+      ),
     ]);
   }
 

--- a/server/utils/validators/checks/story-checks.ts
+++ b/server/utils/validators/checks/story-checks.ts
@@ -1,6 +1,13 @@
 import { prisma } from "@/lib/prisma";
 import { fileExistsInBucket } from "@/utils/storage";
 import { Issue, REQUIRED_LOCALES } from "@/server/utils/validators/types";
+import {
+  computeCoverageRatio,
+  checkTimingIntegrity,
+  COVERAGE_THRESHOLD,
+  FIRST_START_MAX_S,
+  INTER_GAP_MAX_S,
+} from "@/server/utils/validators/sentence-coverage";
 
 export interface StoryForCheck {
   id: string;
@@ -15,6 +22,12 @@ export interface StoryChapterForCheck {
   sentences: unknown;
   translatedSentences: unknown;
   translatedSummary: unknown;
+  /**
+   * The chapter's text passage.  Used for coverage + timing-integrity checks
+   * (issue #138).  Optional for backwards-compat with callers that don't yet
+   * pass it; when absent the coverage check is skipped gracefully.
+   */
+  passage?: string | null;
 }
 
 export async function checkStory(
@@ -51,16 +64,28 @@ async function checkChapter(
   // ── S8: Chapter image ──
   const imgExists = await fileExistsInBucket(`images/story/${id}.png`);
   if (!imgExists) {
-    issues.push({ type: "chapter_image_missing", chapterId: id, chapterNumber });
+    issues.push({
+      type: "chapter_image_missing",
+      chapterId: id,
+      chapterNumber,
+    });
   }
 
   // ── S2: Chapter long audio ──
   if (!chapter.audioSentencesUrl) {
-    issues.push({ type: "chapter_audio_missing", chapterId: id, chapterNumber });
+    issues.push({
+      type: "chapter_audio_missing",
+      chapterId: id,
+      chapterNumber,
+    });
   } else {
     const exists = await fileExistsInBucket(chapter.audioSentencesUrl);
     if (!exists)
-      issues.push({ type: "chapter_audio_missing", chapterId: id, chapterNumber });
+      issues.push({
+        type: "chapter_audio_missing",
+        chapterId: id,
+        chapterNumber,
+      });
   }
 
   // ── S3: Sentences populated ──
@@ -68,7 +93,47 @@ async function checkChapter(
     ? (chapter.sentences as unknown[])
     : [];
   if (sentences.length === 0) {
-    issues.push({ type: "chapter_sentences_empty", chapterId: id, chapterNumber });
+    issues.push({
+      type: "chapter_sentences_empty",
+      chapterId: id,
+      chapterNumber,
+    });
+  }
+
+  // ── S3b: Coverage check — sentence text must cover ≥ COVERAGE_THRESHOLD of passage ──
+  // Only runs when passage is supplied (backwards-compat: callers not yet passing it skip this).
+  // Emits chapter_sentences_partial when stored sentence text covers < ~90% of the passage,
+  // which is the #138 root cause (LLM returns only ~33–37% of passage sentences).
+  if (sentences.length > 0 && chapter.passage) {
+    const coverageRatio = computeCoverageRatio(
+      chapter.sentences,
+      chapter.passage,
+    );
+    if (coverageRatio < COVERAGE_THRESHOLD) {
+      issues.push({
+        type: "chapter_sentences_partial",
+        chapterId: id,
+        chapterNumber,
+        coverageRatio,
+      });
+    }
+  }
+
+  // ── S3c: Timing-integrity checks on SentenceTimepoint[] ──
+  // Catches: non-monotonic timestamps, overlapping windows, first start > 2s,
+  // inter-timepoint gaps > 3s (a missing/dropped sentence).
+  // Silently skips legacy string[] arrays (no timing data present).
+  const timingViolations = checkTimingIntegrity(chapter.sentences, {
+    firstStartMaxS: FIRST_START_MAX_S,
+    interGapMaxS: INTER_GAP_MAX_S,
+  });
+  for (const v of timingViolations) {
+    issues.push({
+      type: "chapter_sentences_timing_integrity",
+      chapterId: id,
+      chapterNumber,
+      detail: `${v.kind}${v.detail ? ": " + v.detail : ""}`,
+    });
   }
 
   // ── S4: translatedSentences per locale + count match ──
@@ -119,7 +184,11 @@ async function checkChapter(
   });
 
   if (!fcRow) {
-    issues.push({ type: "chapter_flashcard_row_missing", chapterId: id, chapterNumber });
+    issues.push({
+      type: "chapter_flashcard_row_missing",
+      chapterId: id,
+      chapterNumber,
+    });
     return;
   }
 

--- a/server/utils/validators/repairs/article-repairs.ts
+++ b/server/utils/validators/repairs/article-repairs.ts
@@ -1,12 +1,19 @@
 import { prisma } from "@/lib/prisma";
 import { Prisma } from "@prisma/client";
 import { generatedImage } from "@/server/utils/genaretors/image-generator";
-import { generateAudio, splitIntoSentences } from "@/server/utils/genaretors/audio-generator";
+import {
+  generateAudio,
+  splitIntoSentences,
+} from "@/server/utils/genaretors/audio-generator";
 import { generateAudioForFlashcard } from "@/server/utils/genaretors/audio-flashcard-generator";
 import { regenerateFlashcardContent } from "@/server/utils/genaretors/flashcard-content-generator";
 import { translateAndStoreSentences } from "@/server/utils/genaretors/sentence-translator";
 import { translateSummary } from "@/server/utils/genaretors/summary-translator";
-import { Issue, RepairAction, RepairResult } from "@/server/utils/validators/types";
+import {
+  Issue,
+  RepairAction,
+  RepairResult,
+} from "@/server/utils/validators/types";
 
 interface ArticleForRepair {
   id: string;
@@ -52,11 +59,15 @@ async function repairAudio(article: ArticleForRepair): Promise<void> {
   });
 }
 
-async function repairTranslatedPassage(article: ArticleForRepair): Promise<void> {
+async function repairTranslatedPassage(
+  article: ArticleForRepair,
+): Promise<void> {
   await translateAndStoreSentences({ articleId: article.id });
 }
 
-async function repairTranslatedSummary(article: ArticleForRepair): Promise<void> {
+async function repairTranslatedSummary(
+  article: ArticleForRepair,
+): Promise<void> {
   const translated = await translateSummary(article.summary, article.cefrLevel);
   await prisma.article.update({
     where: { id: article.id },
@@ -90,11 +101,13 @@ async function repairFlashcardAudio(article: ArticleForRepair): Promise<void> {
     const updateData: Prisma.SentencsAndWordsForFlashcardUpdateInput = {};
     if (sentenceMissing) {
       sentenceData = regenerated.flashcard;
-      updateData.sentence = regenerated.flashcard as unknown as Prisma.InputJsonValue;
+      updateData.sentence =
+        regenerated.flashcard as unknown as Prisma.InputJsonValue;
     }
     if (wordsMissing) {
       wordsData = regenerated.wordlist;
-      updateData.words = regenerated.wordlist as unknown as Prisma.InputJsonValue;
+      updateData.words =
+        regenerated.wordlist as unknown as Prisma.InputJsonValue;
     }
     await prisma.sentencsAndWordsForFlashcard.update({
       where: { id: row.id },
@@ -151,6 +164,8 @@ export function planArticleRepair(
       case "audio_missing":
       case "sentences_empty":
       case "sentences_count_mismatch":
+      case "sentences_partial_coverage":
+      case "sentences_timing_integrity":
         need.audio = true;
         break;
       case "translation_locale_missing":
@@ -176,16 +191,26 @@ export function planArticleRepair(
   if (need.flashcardRow) need.flashcardAudio = false;
 
   const actions: RepairAction[] = [];
-  if (need.images) actions.push(wrap("repair_images", () => repairImages(article)));
-  if (need.audio) actions.push(wrap("repair_audio", () => repairAudio(article)));
+  if (need.images)
+    actions.push(wrap("repair_images", () => repairImages(article)));
+  if (need.audio)
+    actions.push(wrap("repair_audio", () => repairAudio(article)));
   if (need.translatedPassage)
-    actions.push(wrap("repair_translated_passage", () => repairTranslatedPassage(article)));
+    actions.push(
+      wrap("repair_translated_passage", () => repairTranslatedPassage(article)),
+    );
   if (need.translatedSummary)
-    actions.push(wrap("repair_translated_summary", () => repairTranslatedSummary(article)));
+    actions.push(
+      wrap("repair_translated_summary", () => repairTranslatedSummary(article)),
+    );
   if (need.flashcardRow)
-    actions.push(wrap("repair_flashcard_row", () => repairFlashcardRow(article)));
+    actions.push(
+      wrap("repair_flashcard_row", () => repairFlashcardRow(article)),
+    );
   if (need.flashcardAudio)
-    actions.push(wrap("repair_flashcard_audio", () => repairFlashcardAudio(article)));
+    actions.push(
+      wrap("repair_flashcard_audio", () => repairFlashcardAudio(article)),
+    );
   return actions;
 }
 

--- a/server/utils/validators/repairs/story-repairs.ts
+++ b/server/utils/validators/repairs/story-repairs.ts
@@ -1,11 +1,15 @@
 import { prisma } from "@/lib/prisma";
 import { Prisma } from "@prisma/client";
 import { generateStoryImage } from "@/server/utils/genaretors/story-generator";
-import { generateChapterAudio, splitIntoSentences } from "@/server/utils/genaretors/audio-generator";
+import { generateChapterAudio } from "@/server/utils/genaretors/audio-generator";
 import { generateAudioForFlashcard } from "@/server/utils/genaretors/audio-flashcard-generator";
 import { regenerateFlashcardContent } from "@/server/utils/genaretors/flashcard-content-generator";
 import { translateSummary } from "@/server/utils/genaretors/summary-translator";
-import { Issue, RepairAction, RepairResult } from "@/server/utils/validators/types";
+import {
+  Issue,
+  RepairAction,
+  RepairResult,
+} from "@/server/utils/validators/types";
 
 interface StoryForRepair {
   id: string;
@@ -53,19 +57,21 @@ async function repairChapterAudio(
   story: StoryForRepair,
   chapter: ChapterForRepair,
 ): Promise<void> {
-  let sentences = Array.isArray(chapter.sentences)
+  // generateChapterAudio now handles sentence derivation internally:
+  // - If the stored sentences cover ≥90% of the passage, they are reused as-is.
+  // - Otherwise it calls splitIntoSentences(passage) to get full-coverage sentences.
+  // Passing the existing sentences as an optional hint avoids an unnecessary LLM
+  // call when the chapter was only partially broken (e.g. audio missing but
+  // sentences are still good).
+  const hintSentences = Array.isArray(chapter.sentences)
     ? (chapter.sentences as Array<{ sentence?: string } | string>)
         .map((s) => (typeof s === "string" ? s : (s?.sentence ?? "")))
         .filter((s) => s.length > 0)
     : [];
-  // Fall back to splitting the passage when stored sentences are empty —
-  // otherwise the timepoint aligner re-saves [] and the chapter stays broken.
-  if (sentences.length === 0) {
-    sentences = await splitIntoSentences(chapter.passage);
-  }
+
   await generateChapterAudio({
     passage: chapter.passage,
-    sentences,
+    sentences: hintSentences,
     chapterId: chapter.id,
     chapterNumber: chapter.chapterNumber,
     cefrLevel: story.cefrLevel ?? undefined,
@@ -76,15 +82,23 @@ async function repairChapterTranslatedSummary(
   story: StoryForRepair,
   chapter: ChapterForRepair,
 ): Promise<void> {
-  const translated = await translateSummary(chapter.summary, story.cefrLevel ?? undefined);
+  const translated = await translateSummary(
+    chapter.summary,
+    story.cefrLevel ?? undefined,
+  );
   await prisma.storyChapter.update({
     where: { id: chapter.id },
     data: { translatedSummary: translated as unknown as Prisma.InputJsonValue },
   });
 }
 
-async function repairStoryTranslatedSummary(story: StoryForRepair): Promise<void> {
-  const translated = await translateSummary(story.summary, story.cefrLevel ?? undefined);
+async function repairStoryTranslatedSummary(
+  story: StoryForRepair,
+): Promise<void> {
+  const translated = await translateSummary(
+    story.summary,
+    story.cefrLevel ?? undefined,
+  );
   await prisma.story.update({
     where: { id: story.id },
     data: { translatedSummary: translated as unknown as Prisma.InputJsonValue },
@@ -99,7 +113,9 @@ async function repairChapterFlashcardAudio(
     where: { storyChapterId: chapter.id },
   });
   if (!row) {
-    throw new Error("Cannot repair chapter flashcard audio — flashcard row missing");
+    throw new Error(
+      "Cannot repair chapter flashcard audio — flashcard row missing",
+    );
   }
 
   // Flashcards are an AI-curated subset, not the full passage. If either
@@ -118,11 +134,13 @@ async function repairChapterFlashcardAudio(
     const updateData: Prisma.SentencsAndWordsForFlashcardUpdateInput = {};
     if (sentenceMissing) {
       sentenceData = regenerated.flashcard;
-      updateData.sentence = regenerated.flashcard as unknown as Prisma.InputJsonValue;
+      updateData.sentence =
+        regenerated.flashcard as unknown as Prisma.InputJsonValue;
     }
     if (wordsMissing) {
       wordsData = regenerated.wordlist;
-      updateData.words = regenerated.wordlist as unknown as Prisma.InputJsonValue;
+      updateData.words =
+        regenerated.wordlist as unknown as Prisma.InputJsonValue;
     }
     await prisma.sentencsAndWordsForFlashcard.update({
       where: { id: row.id },
@@ -210,6 +228,8 @@ export function planStoryRepair(
         break;
       case "chapter_audio_missing":
       case "chapter_sentences_empty":
+      case "chapter_sentences_partial":
+      case "chapter_sentences_timing_integrity":
         getChapterNeed(issue.chapterId).audio = true;
         break;
       case "chapter_translation_missing":
@@ -235,38 +255,51 @@ export function planStoryRepair(
 
   const actions: RepairAction[] = [];
 
-  if (need.storyCover) actions.push(wrap("repair_story_cover", () => repairStoryCover(ctx.story)));
+  if (need.storyCover)
+    actions.push(wrap("repair_story_cover", () => repairStoryCover(ctx.story)));
 
   for (const [chapterId, n] of chapterNeeds) {
     const chapter = ctx.chaptersById.get(chapterId);
     if (!chapter) continue;
 
     if (n.image)
-      actions.push(wrap(`repair_chapter_image[${chapterId}]`, () =>
-        repairChapterImage(ctx.story, chapter),
-      ));
+      actions.push(
+        wrap(`repair_chapter_image[${chapterId}]`, () =>
+          repairChapterImage(ctx.story, chapter),
+        ),
+      );
     if (n.audio)
-      actions.push(wrap(`repair_chapter_audio[${chapterId}]`, () =>
-        repairChapterAudio(ctx.story, chapter),
-      ));
+      actions.push(
+        wrap(`repair_chapter_audio[${chapterId}]`, () =>
+          repairChapterAudio(ctx.story, chapter),
+        ),
+      );
     if (n.translatedSummary)
-      actions.push(wrap(`repair_chapter_translated_summary[${chapterId}]`, () =>
-        repairChapterTranslatedSummary(ctx.story, chapter),
-      ));
+      actions.push(
+        wrap(`repair_chapter_translated_summary[${chapterId}]`, () =>
+          repairChapterTranslatedSummary(ctx.story, chapter),
+        ),
+      );
     if (n.flashcardRow)
-      actions.push(wrap(`repair_chapter_flashcard_row[${chapterId}]`, () =>
-        repairChapterFlashcardRow(ctx.story, chapter),
-      ));
+      actions.push(
+        wrap(`repair_chapter_flashcard_row[${chapterId}]`, () =>
+          repairChapterFlashcardRow(ctx.story, chapter),
+        ),
+      );
     else if (n.flashcardAudio)
-      actions.push(wrap(`repair_chapter_flashcard_audio[${chapterId}]`, () =>
-        repairChapterFlashcardAudio(ctx.story, chapter),
-      ));
+      actions.push(
+        wrap(`repair_chapter_flashcard_audio[${chapterId}]`, () =>
+          repairChapterFlashcardAudio(ctx.story, chapter),
+        ),
+      );
   }
 
   if (need.storyTranslatedSummary)
-    actions.push(wrap("repair_story_translated_summary", () =>
-      repairStoryTranslatedSummary(ctx.story),
-    ));
+    actions.push(
+      wrap("repair_story_translated_summary", () =>
+        repairStoryTranslatedSummary(ctx.story),
+      ),
+    );
 
   return actions;
 }

--- a/server/utils/validators/sentence-coverage.ts
+++ b/server/utils/validators/sentence-coverage.ts
@@ -1,0 +1,231 @@
+/**
+ * Pure helpers for sentence-coverage and timing-integrity validation.
+ *
+ * These functions are used by both story-checks.ts and article-checks.ts to
+ * detect partial read-along coverage (issue #138 root cause) and
+ * timing anomalies in stored SentenceTimepoints.
+ *
+ * Design constraints:
+ * - No DB queries, no LLM calls, no audio-duration dependency
+ * - Deterministic and fully unit-testable
+ * - Handles both SentenceTimepoint[] (post-alignment) and string[] (legacy)
+ */
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+/** Minimal shape we need from a stored timepoint */
+export interface TimepointLike {
+  sentence: string;
+  startTime: number;
+  endTime: number;
+}
+
+// ─── Text normalisation ───────────────────────────────────────────────────────
+
+/**
+ * Strip punctuation, lowercase, collapse all whitespace to single spaces, and
+ * trim. This mirrors the normalization Lemonfox TTS tokens undergo so that
+ * coverage comparison is stable regardless of punctuation differences.
+ */
+export function normalizeText(text: string): string {
+  return text
+    .replace(/[^\w\s]/g, " ") // strip punctuation (keep alphanumeric + space)
+    .toLowerCase()
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+// ─── Coverage helpers ─────────────────────────────────────────────────────────
+
+/**
+ * Extract the display text from a stored sentences value.
+ *
+ * `sentences` from the DB is typed as `unknown` (Prisma Json). It may be:
+ *   - SentenceTimepoint[]  (post-alignment, the intended shape)
+ *   - string[]             (legacy LLM output before alignment)
+ *   - anything else        (treat as empty)
+ */
+export function extractSentenceText(sentences: unknown): string {
+  if (!Array.isArray(sentences) || sentences.length === 0) return "";
+
+  const parts: string[] = [];
+  for (const item of sentences) {
+    if (typeof item === "string") {
+      // Legacy string[]
+      parts.push(item);
+    } else if (
+      item !== null &&
+      typeof item === "object" &&
+      "sentence" in item &&
+      typeof (item as Record<string, unknown>).sentence === "string"
+    ) {
+      // SentenceTimepoint-like
+      parts.push((item as Record<string, unknown>).sentence as string);
+    }
+  }
+
+  return parts.join(" ");
+}
+
+/**
+ * Compute the coverage ratio: how much of `passage` is covered by the
+ * concatenated sentence text, measured on normalized word tokens.
+ *
+ * Returns a value in [0, 1].
+ *
+ * Algorithm: count unique normalized tokens in `passage` that also appear in
+ * the normalized sentence text. This tolerates minor word-order differences
+ * while still catching large gaps. For a full match the ratio is 1.0.
+ */
+export function computeCoverageRatio(
+  sentences: unknown,
+  passage: string,
+): number {
+  const sentenceText = extractSentenceText(sentences);
+  if (!passage || passage.trim().length === 0) return 1; // empty passage → trivially covered
+
+  const passageNorm = normalizeText(passage);
+  const sentenceNorm = normalizeText(sentenceText);
+
+  if (passageNorm.length === 0) return 1;
+  if (sentenceNorm.length === 0) return 0;
+
+  const passageWords = passageNorm.split(" ").filter(Boolean);
+  if (passageWords.length === 0) return 1;
+
+  // Build a multiset of sentence words for fast lookup
+  const sentenceWordCounts = new Map<string, number>();
+  for (const w of sentenceNorm.split(" ").filter(Boolean)) {
+    sentenceWordCounts.set(w, (sentenceWordCounts.get(w) ?? 0) + 1);
+  }
+
+  // Count passage words that are matched in the sentence multiset
+  const usedCounts = new Map<string, number>();
+  let matched = 0;
+  for (const w of passageWords) {
+    const available =
+      (sentenceWordCounts.get(w) ?? 0) - (usedCounts.get(w) ?? 0);
+    if (available > 0) {
+      usedCounts.set(w, (usedCounts.get(w) ?? 0) + 1);
+      matched++;
+    }
+  }
+
+  return matched / passageWords.length;
+}
+
+// ─── Timing helpers ───────────────────────────────────────────────────────────
+
+export interface TimingViolation {
+  kind:
+    | "non_monotonic"
+    | "overlap"
+    | "first_start_too_late"
+    | "inter_gap_too_large";
+  index?: number; // 0-based index of the timepoint (or the second of a pair)
+  detail?: string;
+}
+
+/**
+ * Validate timing integrity of a stored timepoints array.
+ *
+ * Checks performed:
+ *   1. First startTime must be < FIRST_START_MAX_S (default 2 s) — catches
+ *      a complete desync where no sentence starts near the audio beginning.
+ *   2. Each timepoint: startTime < endTime (non-negative duration).
+ *   3. Sequential pairs: endTime[i] ≤ startTime[i+1] (monotonic, non-overlapping).
+ *   4. Sequential pairs: inter-timepoint gap (startTime[i+1] − endTime[i]) ≤
+ *      INTER_GAP_MAX_S (default 3 s). A larger gap typically signals a missing
+ *      sentence that was dropped by the aligner.
+ *
+ * NOTE: We deliberately omit a tail-vs-audioDuration check because audio
+ * duration is not stored in the DB.
+ */
+export function checkTimingIntegrity(
+  sentences: unknown,
+  options?: {
+    firstStartMaxS?: number;
+    interGapMaxS?: number;
+  },
+): TimingViolation[] {
+  const firstStartMaxS = options?.firstStartMaxS ?? 2;
+  const interGapMaxS = options?.interGapMaxS ?? 3;
+
+  if (!Array.isArray(sentences) || sentences.length === 0) return [];
+
+  // Extract timepoints — only items with numeric startTime/endTime
+  const timepoints: TimepointLike[] = [];
+  for (const item of sentences) {
+    if (
+      item !== null &&
+      typeof item === "object" &&
+      typeof (item as Record<string, unknown>).startTime === "number" &&
+      typeof (item as Record<string, unknown>).endTime === "number" &&
+      typeof (item as Record<string, unknown>).sentence === "string"
+    ) {
+      timepoints.push(item as TimepointLike);
+    }
+  }
+
+  if (timepoints.length === 0) return []; // legacy string[] — no timing to check
+
+  const violations: TimingViolation[] = [];
+
+  // 1. First startTime
+  if (timepoints[0].startTime > firstStartMaxS) {
+    violations.push({
+      kind: "first_start_too_late",
+      index: 0,
+      detail: `startTime=${timepoints[0].startTime.toFixed(2)}s > ${firstStartMaxS}s`,
+    });
+  }
+
+  for (let i = 0; i < timepoints.length; i++) {
+    const tp = timepoints[i];
+
+    // 2. startTime < endTime
+    if (tp.startTime >= tp.endTime) {
+      violations.push({
+        kind: "non_monotonic",
+        index: i,
+        detail: `startTime=${tp.startTime} >= endTime=${tp.endTime}`,
+      });
+    }
+
+    if (i > 0) {
+      const prev = timepoints[i - 1];
+
+      // 3. Non-overlapping: prev.endTime <= tp.startTime
+      if (prev.endTime > tp.startTime) {
+        violations.push({
+          kind: "overlap",
+          index: i,
+          detail: `timepoints[${i - 1}].endTime=${prev.endTime} > timepoints[${i}].startTime=${tp.startTime}`,
+        });
+      }
+
+      // 4. Inter-gap check
+      const gap = tp.startTime - prev.endTime;
+      if (gap > interGapMaxS) {
+        violations.push({
+          kind: "inter_gap_too_large",
+          index: i,
+          detail: `gap=${gap.toFixed(2)}s between timepoints[${i - 1}] and timepoints[${i}]`,
+        });
+      }
+    }
+  }
+
+  return violations;
+}
+
+// ─── Exported thresholds (so callers can reference without magic numbers) ─────
+
+/** Coverage ratio below which we emit a partial-coverage issue */
+export const COVERAGE_THRESHOLD = 0.9;
+
+/** First timepoint startTime must be below this (seconds) */
+export const FIRST_START_MAX_S = 2;
+
+/** Inter-timepoint gap above this triggers a missing-sentence warning (seconds) */
+export const INTER_GAP_MAX_S = 3;

--- a/server/utils/validators/types.ts
+++ b/server/utils/validators/types.ts
@@ -8,8 +8,18 @@ export type Issue =
   | { type: "audio_missing" }
   | { type: "sentences_empty" }
   | { type: "sentences_count_mismatch"; expected: number; actual: number }
-  | { type: "translation_locale_missing"; field: "passage" | "summary"; locale: string }
-  | { type: "translation_count_mismatch"; field: "passage"; locale: string; expected: number; actual: number }
+  | {
+      type: "translation_locale_missing";
+      field: "passage" | "summary";
+      locale: string;
+    }
+  | {
+      type: "translation_count_mismatch";
+      field: "passage";
+      locale: string;
+      expected: number;
+      actual: number;
+    }
   | { type: "flashcard_sentence_audio_missing" }
   | { type: "flashcard_word_audio_missing" }
   | { type: "flashcard_row_missing" }
@@ -19,12 +29,60 @@ export type Issue =
   // Story chapter
   | { type: "chapter_image_missing"; chapterId: string; chapterNumber: number }
   | { type: "chapter_audio_missing"; chapterId: string; chapterNumber: number }
-  | { type: "chapter_sentences_empty"; chapterId: string; chapterNumber: number }
-  | { type: "chapter_translation_missing"; chapterId: string; chapterNumber: number; field: "summary" | "sentences"; locale: string }
-  | { type: "chapter_translation_count_mismatch"; chapterId: string; chapterNumber: number; locale: string; expected: number; actual: number }
-  | { type: "chapter_flashcard_sentence_audio_missing"; chapterId: string; chapterNumber: number }
-  | { type: "chapter_flashcard_word_audio_missing"; chapterId: string; chapterNumber: number }
-  | { type: "chapter_flashcard_row_missing"; chapterId: string; chapterNumber: number };
+  | {
+      type: "chapter_sentences_empty";
+      chapterId: string;
+      chapterNumber: number;
+    }
+  | {
+      type: "chapter_translation_missing";
+      chapterId: string;
+      chapterNumber: number;
+      field: "summary" | "sentences";
+      locale: string;
+    }
+  | {
+      type: "chapter_translation_count_mismatch";
+      chapterId: string;
+      chapterNumber: number;
+      locale: string;
+      expected: number;
+      actual: number;
+    }
+  | {
+      type: "chapter_flashcard_sentence_audio_missing";
+      chapterId: string;
+      chapterNumber: number;
+    }
+  | {
+      type: "chapter_flashcard_word_audio_missing";
+      chapterId: string;
+      chapterNumber: number;
+    }
+  | {
+      type: "chapter_flashcard_row_missing";
+      chapterId: string;
+      chapterNumber: number;
+    }
+  // ── Coverage + timing (issue #138) ──
+  // Article: stored sentence text covers < COVERAGE_THRESHOLD of the passage
+  | { type: "sentences_partial_coverage"; coverageRatio: number }
+  // Article: timing integrity violation (non-monotonic, overlap, gap, early-start)
+  | { type: "sentences_timing_integrity"; detail: string }
+  // Story chapter: stored sentence text covers < COVERAGE_THRESHOLD of the passage
+  | {
+      type: "chapter_sentences_partial";
+      chapterId: string;
+      chapterNumber: number;
+      coverageRatio: number;
+    }
+  // Story chapter: timing integrity violation
+  | {
+      type: "chapter_sentences_timing_integrity";
+      chapterId: string;
+      chapterNumber: number;
+      detail: string;
+    };
 
 // ─── Repair plan + result ────────────────────────────────────────────────────
 
@@ -45,7 +103,7 @@ export interface ValidationOutcome {
   id: string;
   status: ValidationStatus;
   attempts: number;
-  issues: Issue[];      // post-repair remaining issues; empty if OK
+  issues: Issue[]; // post-repair remaining issues; empty if OK
   repairsRun: RepairResult[];
 }
 


### PR DESCRIPTION
  Read-along (#138): derive sentences from passage (conditional split via
  splitIntoSentences), rewrite processWordTimestampsIntoSentences into a 0-drop
  tolerant aligner, per-sentence translation fallback, validator coverage +
  timing checks, frontend sticky-highlight + unified render (no reflow).

  Publish-on-validate: validation sets isPublished=true on finalStatus=OK
  (story + article); stories now generated unpublished, published once validated.